### PR TITLE
changed MFA result handling conditional to include bool

### DIFF
--- a/bin/aad_aws_login
+++ b/bin/aad_aws_login
@@ -308,7 +308,7 @@ def start_phone_app_mfa(session, begin_auth_url, end_auth_url, process_auth_url,
                                         headers={u"Accept": u"application/json", u"Content-Type": u"application/json"})
         # print(mfa_end_response.text)
         auth_end = mfa_end_response.json()
-        if auth_end["Result"] == "true":
+        if auth_end["Result"] in ("true", "True", True):
             return finish_mfa(session=session, process_auth_url=process_auth_url, request=auth_end["Ctx"],
                               flow_token=auth_end["FlowToken"], canary=canary, mfa_auth_method="PhoneAppNotification")
         elif auth_end["Retry"] == "false":
@@ -344,7 +344,8 @@ def start_token_mfa(session, mfa_auth_method, begin_auth_url, end_auth_url, proc
                                     headers={u"Accept": u"application/json", u"Content-Type": u"application/json"})
     # print(mfaresp2.text)
     auth_end = mfa_end_response.json()
-    if auth_end["Result"] == "true":
+    
+    if auth_end["Result"] in ("true", "True", True):
         return finish_mfa(session=session, process_auth_url=process_auth_url, request=auth_end["Ctx"],
                           flow_token=auth_end["FlowToken"], canary=canary, mfa_auth_method=mfa_auth_method)
         # data = {"request": auth_end["Ctx"], "flowToken": auth_end["FlowToken"], "canary": payload["canary"], "mfaAuthMethod": mfaAuthMethodId.group(1), "rememberMFA": "false"}


### PR DESCRIPTION
Apparently overnight the MFA response JSON `{"Result": "true"}` changed to `{"Result": True}`, so string to bool. This caused `MFA failed` both for MFA app as well as SMS token response. Changed response handling code to include `"true"`, `"True"` and `True`.